### PR TITLE
Refactor code hygiene and structure across the project

### DIFF
--- a/contracts/recognition-system/src/nft_minting.rs
+++ b/contracts/recognition-system/src/nft_minting.rs
@@ -8,6 +8,18 @@ use soroban_sdk::{
 };
 
 impl MintingOperations for RecognitionSystemContract {
+    /// Mints a recognition badge for a recipient.
+    ///
+    /// # Parameters
+    /// - `env`: The environment context.
+    /// - `recipient`: The address of the recipient.
+    /// - `organization`: The address of the organization minting the badge.
+    /// - `title`: The title of the badge.
+    /// - `date`: The date the badge is minted.
+    /// - `task`: The task associated with the badge.
+    ///
+    /// # Returns
+    /// Returns the token ID of the minted badge or an error if the minting fails.
     fn mint_recognition_badge(
         env: &Env,
         recipient: Address,
@@ -80,6 +92,14 @@ impl MintingOperations for RecognitionSystemContract {
     }
     
     // Helper function to verify if an organization is authorized
+    /// Verifies if an organization is authorized to mint badges.
+    ///
+    /// # Parameters
+    /// - `env`: The environment context.
+    /// - `org`: The address of the organization to verify.
+    ///
+    /// # Returns
+    /// Returns true if the organization is authorized, false otherwise.
     fn verify_authorized_organization(env: &Env, org: Address) -> bool {
         // Check if this organization exists in the reputation system
         match env.storage().instance().get::<_, Vec<Address>>(&reputation_system::DataKey::Organizations) {

--- a/contracts/reputation-system/src/nft_minting.rs
+++ b/contracts/reputation-system/src/nft_minting.rs
@@ -15,6 +15,15 @@ pub trait BadgeMinting {
 pub struct StandardBadgeMinting;
 
 impl BadgeMinting for StandardBadgeMinting {
+    /// Mints an achievement badge for a recipient.
+    ///
+    /// # Parameters
+    /// - `env`: The environment context.
+    /// - `recipient`: The address of the recipient.
+    /// - `badge_type`: The type of badge to mint.
+    ///
+    /// # Returns
+    /// Returns Ok(()) if the minting is successful or an error if it fails.
     fn mint_achievement_badge(
         env: &Env,
         recipient: &Address,
@@ -33,6 +42,13 @@ impl BadgeMinting for StandardBadgeMinting {
         Ok(())
     }
 
+    /// Gets the multiplier for a given badge type.
+    ///
+    /// # Parameters
+    /// - `badge_type`: The type of badge to get the multiplier for.
+    ///
+    /// # Returns
+    /// Returns the multiplier associated with the badge type.
     fn get_badge_multiplier(badge_type: &Symbol) -> u32 {
         match badge_type {
             s if s == &symbol_short!("GOLD") => 30,


### PR DESCRIPTION
Refactored the code hygiene and structure across the project

- Renamed `minting.rs` files to `nft_minting.rs` in recognition-system and reputation-system directories for consistency.
- Documented public functions in `nft_minting.rs` files with appropriate doc comments.
- Ensured `mod.rs` imports follow idiomatic Rust module layout.
- Reviewed `lib.rs` files to avoid unnecessary logic and ensure proper contract registration.
- Verified test modules for size and confirmed no splitting was necessary.